### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,6 @@
 name: Upload coverage reports to Codecov
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/phothinmg/ptm-multiregexp/security/code-scanning/2](https://github.com/phothinmg/ptm-multiregexp/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/codecov.yml`. The block should be placed at the root level (above `jobs:`) to apply to all jobs in the workflow. Since the workflow only checks out code and uploads coverage reports, it only needs read access to repository contents. Therefore, set `contents: read` as the minimal required permission. No other permissions are needed. The change should be made by inserting the following lines after the workflow `name` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
